### PR TITLE
Fix clean regex typo

### DIFF
--- a/background.js
+++ b/background.js
@@ -54,7 +54,7 @@ chrome.webRequest.onSendHeaders.addListener((details) => {
 }, {urls: ["https://*.soundcloud.com/*"]})
 
 const clean = (text) => {
-  return text?.replace(/[^a-z0-9_-\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf【】()\[\]&!#. ]/gi, "").replace(/~/g, "").replace(/ +/g, " ").trim() ?? ""
+  return text?.replace(/[^a-z0-9_\-\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf【】(){}\[\]&!#. ]/gi, "").replace(/~/g, "").replace(/ +/g, " ").trim() ?? ""
 }
 
 const downloadM3U = async (url) => {


### PR DESCRIPTION
The problem is with the hyphen between _ and \u3000. I'm sure it's not intentional, because this way the next hyphen between \u3000 and \u303f is taken as a literal hyphen, not a range.
```
[^a-z0-9_-\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf【】()\[\]&!#. ]
         ^
```
Example characters that slipped through: | (pipe), { } (no problem with these, I just think it was not intentional), U+200B (zero width space - caused some headache to figure out this one).
I think escaping the hyphen after the underline and adding {} explicitly (since it was implicitly allowed so until now) should be fine. But characters between _ and \u3000 were allowed, now these would be disallowed.
Please do think about the change, we don't want to break some edge case with this.
This time I tried it 😉